### PR TITLE
fix slave_class - exclude string 'orders' from check this  was obstac…

### DIFF
--- a/lib/slave_class.php
+++ b/lib/slave_class.php
@@ -8,8 +8,10 @@ class slave
         if (
             !strpos($text, "select") && //
             !strpos($text, "union") && //
-            !strpos($text, "select") && //
-            !strpos($text, "order") && // Ищем вхождение слов в параметре
+//            !strpos($text, "order") && // Ищем вхождение слов в параметре //4.02.2017 закоментировал по причине westruckorders@gmail.com кл 26846
+            !strpos($text, "delete") && //
+            !strpos($text, "update") && //
+            !strpos($text, "insert") && //
             !strpos($text, "where") && //
             !strpos($text, "from") //
         ) {


### PR DESCRIPTION
…le to authorize some klients with such emails that contain 'order'